### PR TITLE
Fix sprite image mixin

### DIFF
--- a/spec/sass_mixins_spec.rb
+++ b/spec/sass_mixins_spec.rb
@@ -1,0 +1,29 @@
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+
+describe "lemonade.scss" do
+
+  before :each do
+    Lemonade.reset
+    FileUtils.cp_r File.dirname(__FILE__) + '/images', IMAGES_TMP_PATH
+  end
+
+  after :each do
+    FileUtils.rm_r IMAGES_TMP_PATH
+  end
+
+  def evaluate(*values)
+    sass = '@import "lemonade"' + "\n" +
+           "div" + values.map{ |value| "\n #{value}" }.join
+    path = File.expand_path(File.dirname(__FILE__) + '/../stylesheets')
+    css = Sass::Engine.new(sass, :syntax => :sass, :load_paths => [path]).render
+    # find rendered CSS values strip selectors hitespace
+    css = css.gsub(/div \{\s*(.+?);\s*\}\s*/m, '\\1')
+    css = css.first if css.length == 1
+    return css
+  end
+  
+  it "should have `sprite_image` mixin" do
+    evaluate('+sprite-image("sprites/30x30.png")').should == "background: url('/sprites.png')"
+  end
+  
+end

--- a/stylesheets/lemonade.scss
+++ b/stylesheets/lemonade.scss
@@ -4,7 +4,7 @@
 }
 
 @mixin sprite-image($file) {
-  background: sprite-image($file) $repeat;
+  background: sprite-image($file);
 }
 
 @mixin sized-sprite-image($file) {


### PR DESCRIPTION
I add spec file for mixin and fix hagenburger/lemonade#11.

Spec file isn’t very pretty, but I didn’t brave to refactoring your project :). I think before and after filters must be move to some function in `spec_helper.rb`.

Also, I didn’t write specs for all mixins, because have problems. As I understand `image-width` is a Compass function and I didn’t know how to enable it in specs.
