### PR TITLE
Add repeat-x functionality 

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ If you need empty space around the current image, this will add 20px transparent
     .seven-up {
       background: sprite-image("bottles/seven-up.png", 0, 0, 20px);
     }
-    
+
 This one adds 20px above, 30px below:
-    
+
     .seven-up {
       background: sprite-image("bottles/seven-up.png", 0, 0, 20px, 30px);
     }
@@ -97,9 +97,13 @@ Right aligned images are possible:
     .seven-up {
       background: sprite-image("bottles/seven-up.png", 100%, 4px);
     }
-    
+
 The original image will be placed on the right side of the sprite image.
 Use this, if you have a link with an arrow on the right side (like Apple).
+
+For 1 pixel wide type repeats, you can fill out the image so repeat-x will work.
+
+      background: sprite-image("bottles/vertical-orange.png", 0, 0, 0, 0, true);
 
 
 Note on Patches/Pull Requests

--- a/lib/lemonade.rb
+++ b/lib/lemonade.rb
@@ -104,14 +104,23 @@ module Lemonade
       sprite[:height] = y
       sprite[:width] = width
     end
-    
+
     def generate_sprite_image(sprite)
       sprite_image = ChunkyPNG::Image.new(sprite[:width], sprite[:height], ChunkyPNG::Color::TRANSPARENT)
       sprite[:images].each do |sprite_item|
         sprite_item_image  = ChunkyPNG::Image.from_file(sprite_item[:file])
         x = (sprite[:width] - sprite_item[:width]) * (sprite_item[:x].value / 100)
         y = sprite_item[:y].value
-        sprite_image.replace sprite_item_image, x, y
+
+        if sprite_item[:repeat]
+          copies = (sprite[:width]/sprite_item[:width]).to_i
+        else
+          copies = 1
+        end
+
+        copies.times do |i|
+          sprite_image.replace sprite_item_image, x + i*sprite_item[:width], y
+        end
       end
       sprite_image.save File.join(Lemonade.images_path, sprite[:file])
     end

--- a/lib/lemonade/sass_functions.rb
+++ b/lib/lemonade/sass_functions.rb
@@ -6,13 +6,13 @@ module Sass::Script::Functions
     Sass::Script::SpriteInfo.new(:url, sprite)
   end
 
-  def sprite_position(file, position_x = nil, position_y_shift = nil, margin_top_or_both = nil, margin_bottom = nil)
-    sprite, sprite_item = sprite_url_and_position(file, position_x, position_y_shift, margin_top_or_both, margin_bottom)
+  def sprite_position(file, position_x = nil, position_y_shift = nil, margin_top_or_both = nil, margin_bottom = nil, repeat = nil)
+    sprite, sprite_item = sprite_url_and_position(file, position_x, position_y_shift, margin_top_or_both, margin_bottom, repeat)
     Sass::Script::SpriteInfo.new(:position, sprite, sprite_item, position_x, position_y_shift)
   end
 
-  def sprite_image(file, position_x = nil, position_y_shift = nil, margin_top_or_both = nil, margin_bottom = nil)
-    sprite, sprite_item = sprite_url_and_position(file, position_x, position_y_shift, margin_top_or_both, margin_bottom)
+  def sprite_image(file, position_x = nil, position_y_shift = nil, margin_top_or_both = nil, margin_bottom = nil, repeat = nil)
+    sprite, sprite_item = sprite_url_and_position(file, position_x, position_y_shift, margin_top_or_both, margin_bottom, repeat)
     Sass::Script::SpriteInfo.new(:both, sprite, sprite_item, position_x, position_y_shift)
   end
   alias_method :sprite_img, :sprite_image
@@ -48,13 +48,13 @@ private
     Dir.glob(File.join(dir, '*.png')).sort
   end
 
-  def sprite_url_and_position(file, position_x = nil, position_y_shift = nil, margin_top_or_both = nil, margin_bottom = nil)
+  def sprite_url_and_position(file, position_x = nil, position_y_shift = nil, margin_top_or_both = nil, margin_bottom = nil, repeat = nil)
     dir, name, basename = extract_names(file, :check_file => true)
     filestr = File.join(Lemonade.sprites_path, file.value)
 
     sprite_file = "#{dir}#{name}.png"
     sprite = sprite_for(sprite_file)
-    sprite_item = image_for(sprite, filestr, position_x, position_y_shift, margin_top_or_both, margin_bottom)
+    sprite_item = image_for(sprite, filestr, position_x, position_y_shift, margin_top_or_both, margin_bottom, repeat)
 
     # Create a temporary destination file so compass doesn't complain about a missing image
     FileUtils.touch File.join(Lemonade.images_path, sprite_file)
@@ -85,11 +85,14 @@ private
       }
   end
 
-  def image_for(sprite, file, position_x, position_y_shift, margin_top_or_both, margin_bottom)
+  def image_for(sprite, file, position_x, position_y_shift, margin_top_or_both, margin_bottom, repeat)
     image = sprite[:images].detect{ |image| image[:file] == file }
     margin_top_or_both ||= Sass::Script::Number.new(0)
     margin_top = margin_top_or_both.value #calculate_margin_top(sprite, margin_top_or_both, margin_bottom)
     margin_bottom = (margin_bottom || margin_top_or_both).value
+    if repeat
+      repeat == 'true' ? true: false
+    end
     if image
       image[:margin_top] = margin_top if margin_top > image[:margin_top]
       image[:margin_bottom] = margin_bottom if margin_bottom > image[:margin_bottom]
@@ -105,7 +108,8 @@ private
         :x => x,
         :margin_top => margin_top,
         :margin_bottom => margin_bottom,
-        :index => sprite[:images].length
+        :index => sprite[:images].length,
+        :repeat => repeat
       }
       sprite[:images] << image
     end

--- a/spec/sass_functions_spec.rb
+++ b/spec/sass_functions_spec.rb
@@ -213,4 +213,16 @@ describe Sass::Script::Functions do
     evaluate('image-basename("sprites/10x10.png")').should == "10x10"
   end
 
+  // FIXME How can we test it actually repeated the 10x10 twice?
+  it "should accept a repeat argument" do
+    evaluate(
+      'sprite-image("sprites/10x10.png", 0, 0, 0, 0, true)',
+      'sprite-image("sprites/20x20.png")'
+    ).should == [
+      "url('/sprites.png')",
+      "url('/sprites.png') 0 -10px"
+    ]
+    image_size('sprites.png').should == [20, 30]
+  end
+
 end


### PR DESCRIPTION
Add a repeat argument to sprite-image. If true then the resulting image will be copied into the sprite multiple times to fill it's width.

This is is ueful or when your sprite has multiple images of different widths and you want to repeat-x a 1 pixel wide image.
