### PR TITLE
named_sprite_image

### DIFF
--- a/lib/lemonade.rb
+++ b/lib/lemonade.rb
@@ -1,5 +1,6 @@
 require 'chunky_png'
 require 'lemonade/sprite_info.rb'
+require 'yaml'
 
 module Lemonade
   @@sprites = {}

--- a/lib/lemonade/sass_functions.rb
+++ b/lib/lemonade/sass_functions.rb
@@ -57,7 +57,7 @@ private
     filestr = File.join(Lemonade.sprites_path, file.value)
 
     sprite_file ||= "#{dir}#{name}.png"
-    sprite_file = sprite_file << '.png' unless sprite_file.end_with?('.png')
+    sprite_file = "#{sprite_file}.png" unless sprite_file =~ /\.png$/
     sprite = sprite_for(sprite_file)
     sprite_item = image_for(sprite, filestr, position_x, position_y_shift, margin_top_or_both, margin_bottom)
 

--- a/lib/lemonade/sass_functions.rb
+++ b/lib/lemonade/sass_functions.rb
@@ -11,11 +11,15 @@ module Sass::Script::Functions
     Sass::Script::SpriteInfo.new(:position, sprite, sprite_item, position_x, position_y_shift)
   end
 
-  def sprite_image(file, position_x = nil, position_y_shift = nil, margin_top_or_both = nil, margin_bottom = nil)
-    sprite, sprite_item = sprite_url_and_position(file, position_x, position_y_shift, margin_top_or_both, margin_bottom)
+  def sprite_image(file, position_x = nil, position_y_shift = nil, margin_top_or_both = nil, margin_bottom = nil, sprite_file = nil)
+    sprite, sprite_item = sprite_url_and_position(file, position_x, position_y_shift, margin_top_or_both, margin_bottom, sprite_file)
     Sass::Script::SpriteInfo.new(:both, sprite, sprite_item, position_x, position_y_shift)
   end
   alias_method :sprite_img, :sprite_image
+
+  def named_sprite_image(file, sprite_file, position_x = nil, position_y_shift = nil, margin_top_or_both = nil, margin_bottom = nil)
+    sprite_image(file, position_x, position_y_shift, margin_top_or_both, margin_bottom, sprite_file.value)
+  end
 
   def sprite_files_in_folder(folder)
     assert_type folder, :String
@@ -48,11 +52,12 @@ private
     Dir.glob(File.join(dir, '*.png')).sort
   end
 
-  def sprite_url_and_position(file, position_x = nil, position_y_shift = nil, margin_top_or_both = nil, margin_bottom = nil)
+  def sprite_url_and_position(file, position_x = nil, position_y_shift = nil, margin_top_or_both = nil, margin_bottom = nil, sprite_file = nil)
     dir, name, basename = extract_names(file, :check_file => true)
     filestr = File.join(Lemonade.sprites_path, file.value)
 
-    sprite_file = "#{dir}#{name}.png"
+    sprite_file ||= "#{dir}#{name}.png"
+    sprite_file = sprite_file << '.png' unless sprite_file.end_with?('.png')
     sprite = sprite_for(sprite_file)
     sprite_item = image_for(sprite, filestr, position_x, position_y_shift, margin_top_or_both, margin_bottom)
 

--- a/spec/sass_functions_spec.rb
+++ b/spec/sass_functions_spec.rb
@@ -213,4 +213,25 @@ describe Sass::Script::Functions do
     evaluate('image-basename("sprites/10x10.png")').should == "10x10"
   end
 
+  it "should return the specified sprite file name" do
+    evaluate('named-sprite-image("sprites/30x30.png", "named_sprites.png")').should == "url('/named_sprites.png')"
+  end
+
+  it "should return sprite file name with .png extension" do
+    evaluate('named-sprite-image("sprites/30x30.png", "named_sprites")').should == "url('/named_sprites.png')"
+  end
+
+  it "should accept optional arguments for named-sprite-image" do
+    evaluate(
+      'named-sprite-image("sprites/10x10.png", "named_sprites.png")',
+      'named-sprite-image("sprites/20x20.png", "named_sprites.png", 5px, 0, 0, 15px)',
+      'named-sprite-image("sprites/30x30.png", "named_sprites.png", 0, 5px, 20px)'
+    ).should == [
+      "url('/named_sprites.png')",
+      "url('/named_sprites.png') 5px -10px",
+      "url('/named_sprites.png') 0 -45px"
+    ]
+    image_size('named_sprites.png').should == [30, 80]
+  end
+
 end


### PR DESCRIPTION
Hi,

First, thanks for the awesome gem!  What a great idea...going to be such a time saver and performance enhancer.

As I was starting to use it for a project, I wanted to be able to specify the generated sprite file name explicitly rather than have it auto determined from the path of the image file.  I added an optional sprite_file argument at the end of sprite_image.  I also created a separate named_sprite_image method so that the file name arg is the second argument for more convenience.  The named_sprite_image then just calls the sprite_image method.  Tests included.

Hope you find this useful as well.

Cheers,
Steve
