### PR TITLE
Make Lemonade sprites for a images relatively SASS files

### DIFF
--- a/lib/lemonade.rb
+++ b/lib/lemonade.rb
@@ -1,13 +1,22 @@
 require 'chunky_png'
 require 'lemonade/sprite_info.rb'
+require 'yaml'
 
 module Lemonade
   @@sprites = {}
   @@sprites_path = nil
   @@images_path = nil
-
+  @@last_imported_full_filename = nil
   class << self
-
+  
+    def last_imported_full_filename
+      @@last_imported_full_filename
+    end
+	
+    def last_imported_full_filename=(full_filename)
+      @@last_imported_full_filename = full_filename
+    end
+	
     def sprites
       @@sprites
     end

--- a/lib/lemonade/sass_extension.rb
+++ b/lib/lemonade/sass_extension.rb
@@ -19,3 +19,24 @@ module Sass
   end
 
 end
+
+
+module Sass
+
+  module Tree
+
+    class ImportNode < RootNode
+	  
+		alias_method :_perform_without_lemonade, :_perform
+		def _perform(environment)
+		  # ru: Последний импортированный sass файл.
+		  # en: set last imported sass filename
+		  Lemonade.last_imported_full_filename = full_filename
+		  _perform_without_lemonade environment  
+		end
+	
+    end
+
+  end
+
+end


### PR DESCRIPTION
This revision adds the ability to make Lemonade sprites for a images relatively SASS files, instead of the standard way - relatively Lemonade.images_path.
